### PR TITLE
Fix README markdown headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 *A collaborative and comprehensive glossary of user experience terms and jargon. Supported by the Open Design School (opendesignschool.co.uk) and UX Mastery (uxmastery.com).*
 
 
-##Goals & Scope
+## Goals & Scope
 
 Hello there! This project aims to collate a comprehensive glossary of user experience terms, jargon, acronyms and abbreviations. It exists as a reference for people studying and working in UX.
 
@@ -11,14 +11,14 @@ We welcome contributions from anyone practicing in the UX field, with any level 
 The terms need not be UX-specific, but should be used largely within the user experience community.
 
 
-##Contributing to the glossary
+## Contributing to the glossary
 
 We'd love to include your definitions in the glossary. If you see something we don't have yet, please share it with us. 
 
-####Style
+### Style
 Definitions should be written from a *neutral*, *non-partisan* point of view, and should, where possible, avoid using jargon themselves. Bonus points if you can include a link to additional resources.
 
-####Adding or modifying a term
+### Adding or modifying a term
 To add or modify a term:
 
 1. Navigate to the glossary file, i.e. [glossary_en.md](https://github.com/uxmastery/ux-glossary/blob/master/glossary_en.md)
@@ -29,16 +29,16 @@ To add or modify a term:
 
 This will create a pull request, to which you will be automatically subscribed, and allow the community to weigh on on the merits of your proposed addition and consider it for inclusion in the glossary.
 
-####Suggest changes 
+### Suggest changes 
 To suggest a term, [review the existing issues](https://github.com/uxmastery/ux-glossary/issues), and if not already listed, [create a new one](https://github.com/uxmastery/ux-glossary/issues/new).
 
 Even better, if you have a starting point for a definition you'd like to propose, consider adding the term yourself, as described above
 
-####Create a translation
+### Create a translation
 Translations of this content are welcomed and encouraged. To begin, create a copy of the glossary file and append an underscore and the [appropriate ISO 639-1 language code](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) to the filename. i.e. glossary__uk.md for a Ukrainian translation.
 
-##Licence
+## Licence
 The Collaborative UX Glossary is licenced under a Creative Commons [Attribution-ShareAlike 4.0 International](http://creativecommons.org/licenses/by-sa/4.0/) (CC BY-SA 4.0) By contributing to The Collaborative UX Glossary, you license your contribution under the same terms with which the project is distributed.
 
-##Contact
+## Contact
 If you get stuck or have questions, please contact support@uxmastery.com


### PR DESCRIPTION
Hey! I'm not sure if you still maintain this repo actively but I noticed that the headers in `README.md` are not set correctly (no space after the hash characters).

This PR fixes the headers in `README.md`.